### PR TITLE
s22-4pm-2: mh-added updates to appnavbar 

### DIFF
--- a/frontend/src/stories/components/Nav/AppNavbar.stories.js
+++ b/frontend/src/stories/components/Nav/AppNavbar.stories.js
@@ -2,6 +2,8 @@
 import React from 'react';
 
 import AppNavbar from "main/components/Nav/AppNavbar";
+import { currentUserFixtures } from 'fixtures/currentUserFixtures';
+import { systemInfoFixtures } from 'fixtures/systemInfoFixtures';
 
 export default {
     title: 'components/Nav/AppNavbar',
@@ -15,27 +17,61 @@ const Template = (args) => {
     )
 };
 
-export const noRole = Template.bind({});
+export const basic_notLoggedIn = Template.bind({});
 
-export const admin = Template.bind({});
-admin.args = {
-    role: "admin"
+
+export const basic_loggedInAdminUser = Template.bind({});
+basic_loggedInAdminUser.args = {
+    currentUser: currentUserFixtures.adminUser
 };
 
-export const localhost3000 = Template.bind({});
-localhost3000.args = {
+export const basic_loggedInRegularUser = Template.bind({});
+basic_loggedInRegularUser.args = {
+    currentUser: currentUserFixtures.userOnly
+};
+
+export const extraLinks_neitherH2NorSwagger = Template.bind({});
+extraLinks_neitherH2NorSwagger.args = {
+    currentUser: currentUserFixtures.userOnly,
+    systemInfo: systemInfoFixtures.showingNeither
+};
+
+export const extraLinks_H2Only = Template.bind({});
+extraLinks_H2Only.args = {
+    currentUser: currentUserFixtures.userOnly,
+    systemInfo: {
+        "springH2ConsoleEnabled": true,
+        "showSwaggerUILink": false,
+    }
+};
+
+export const extraLinks_SwaggerOnly = Template.bind({});
+extraLinks_SwaggerOnly.args = {
+    currentUser: currentUserFixtures.userOnly,
+    systemInfo: {
+        "springH2ConsoleEnabled": false,
+        "showSwaggerUILink": true,
+    }
+};
+
+export const extraLinks_bothH2AndSwagger = Template.bind({});
+extraLinks_bothH2AndSwagger.args = {
+    currentUser: currentUserFixtures.userOnly,
+    systemInfo: systemInfoFixtures.showingBoth
+};
+
+
+export const localhost_3000 = Template.bind({});
+localhost_3000.args = {
     currentUrl: "http://localhost:3000"
 };
 
-export const localhostNumeric3000 = Template.bind({});
-localhostNumeric3000.args = {
+export const localhost_127_0_0_1__3000 = Template.bind({});
+localhost_127_0_0_1__3000.args = {
     currentUrl: "http://127.0.0.1:3000"
 };
 
-export const localhost8080 = Template.bind({});
-localhost8080.args = {
+export const localhost_8080 = Template.bind({});
+localhost_8080.args = {
     currentUrl: "http://localhost:8080"
 };
-
-
-


### PR DESCRIPTION
# Overview
In this PR, we added more stories to the storybook for navbar.
The additional stories now show that the users are logged in as an admin, logged in as a regular user, and whether the H2 and Swagger links are presented.

Here's the storybook link: https://ucsb-cs156-s22.github.io/s22-4pm-courses-docs-qa/storybook-qa/AppNavBar-MH/?path=/story/components-nav-appnavbar--basic-logged-in-admin-user

# Details
## Before
There are only few stories under navbar.
![image](https://user-images.githubusercontent.com/62964478/170907155-fe3d3158-07d3-45ca-9555-f250169decc1.png)

## After
We can see that there are more stories for navbar now!
![image](https://user-images.githubusercontent.com/62964478/170906964-cd40c993-6347-4177-9349-412cfd595265.png)

Additionally, they show what they were supposed to be. For example, H2 and Swagger are shown now!
![image](https://user-images.githubusercontent.com/62964478/170907223-56d89edb-f30d-4f6a-886f-d4bbec33fded.png)

