### PR TITLE
s22-4pm-1: Suppress error messages for frontend tests

### DIFF
--- a/frontend/src/tests/components/BasicCourseSearch/BasicCourseSearchForm.test.js
+++ b/frontend/src/tests/components/BasicCourseSearch/BasicCourseSearchForm.test.js
@@ -18,6 +18,12 @@ jest.mock("react-toastify", () => ({
 }));
 
 describe("BasicCourseSearchForm tests", () => {
+
+  beforeEach(() => {
+    jest.spyOn(console, 'error')
+    console.error.mockImplementation(() => null);
+  });
+
   const axiosMock = new AxiosMockAdapter(axios);
   beforeEach(() => {
     axiosMock

--- a/frontend/src/tests/components/Subjects/SingleSubjectDropdown.test.js
+++ b/frontend/src/tests/components/Subjects/SingleSubjectDropdown.test.js
@@ -15,6 +15,12 @@ jest.mock("react", () => ({
 }));
 
 describe("SingleSubjectDropdown tests", () => {
+
+  beforeEach(() => {
+    jest.spyOn(console, 'error')
+    console.error.mockImplementation(() => null);
+  });
+
   beforeEach(() => {
     useState.mockImplementation(jest.requireActual("react").useState);
   });
@@ -22,6 +28,10 @@ describe("SingleSubjectDropdown tests", () => {
   afterEach(() => {
     jest.clearAllMocks();
   });
+
+  afterEach(() => {
+    console.error.mockRestore();
+ })
 
   const subject = jest.fn();
   const setSubject = jest.fn();

--- a/frontend/src/tests/pages/HomePage.test.js
+++ b/frontend/src/tests/pages/HomePage.test.js
@@ -25,6 +25,11 @@ describe("HomePage tests", () => {
   const axiosMock = new AxiosMockAdapter(axios);
 
   beforeEach(() => {
+    jest.spyOn(console, 'error')
+    console.error.mockImplementation(() => null);
+  });
+
+  beforeEach(() => {
     axiosMock.resetHistory();
     axiosMock
       .onGet("/api/currentUser")


### PR DESCRIPTION
# Overview

This PR implements the required code to suppress the great wall of errors for frontend testing. This is necessary for having a clean and clear `npm test` output. 

# Issues Addressed

Closes #34 

# Details

## Before

![Screenshot_20220530_155935](https://user-images.githubusercontent.com/59896939/171066319-1b4d4f49-ebad-4cda-b2c2-5bb3766ad126.png)

## After

![Screenshot_20220530_155830](https://user-images.githubusercontent.com/59896939/171066266-64992095-8432-4b12-ab62-20b765d1bf32.png)

# Test Plan (for interactive testing)

Simply run `npm test` and verify that there are no more walls of red errors.

