### PR TITLE
s22-4pm-team1-Harry Li  added section and page and navbar

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -12,6 +12,8 @@ import "bootstrap/dist/css/bootstrap.css";
 import PersonalSchedulesIndexPage from "main/pages/PersonalSchedules/PersonalSchedulesIndexPage";
 import PersonalSchedulesCreatePage from "main/pages/PersonalSchedules/PersonalSchedulesCreatePage";
 
+import SectionSearchesIndexPage from "main/pages/SectionSearches/SectionSearchesIndexPage";
+
 
 function App() {
 
@@ -36,6 +38,13 @@ function App() {
             <>
               <Route exact path="/personalschedules/list" element={<PersonalSchedulesIndexPage />} />
               <Route exact path="/personalschedules/create" element={<PersonalSchedulesCreatePage />} />
+            </>
+          )
+        }
+        {
+          hasRole(currentUser, "ROLE_USER") && (
+            <>
+              <Route exact path="/sectionsearches/search" element={<SectionSearchesIndexPage />} />
             </>
           )
         }

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -59,6 +59,16 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
               }
             </Nav>
 
+            <Nav className="mr-auto">
+              {
+                hasRole(currentUser, "ROLE_USER") && (
+                  <NavDropdown title="Section Searches" id="appnavbar-section-searches-dropdown" data-testid="appnavbar-section-searches-dropdown" >
+                    <NavDropdown.Item href="/sectionsearches/search" data-testid="appnavbar-section-searches-search">search</NavDropdown.Item>
+                  </NavDropdown>
+                )
+              }
+            </Nav>
+
 
 
             

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -63,7 +63,7 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
               {
                 hasRole(currentUser, "ROLE_USER") && (
                   <NavDropdown title="Section Searches" id="appnavbar-section-searches-dropdown" data-testid="appnavbar-section-searches-dropdown" >
-                    <NavDropdown.Item href="/sectionsearches/search" data-testid="appnavbar-section-searches-search">search</NavDropdown.Item>
+                    <NavDropdown.Item href="/sectionsearches/search" data-testid="appnavbar-section-searches-search">Search</NavDropdown.Item>
                   </NavDropdown>
                 )
               }

--- a/frontend/src/main/components/Sections/SectionsTable.js
+++ b/frontend/src/main/components/Sections/SectionsTable.js
@@ -45,10 +45,6 @@ export default function SectionsTable({ sections }) {
         {
             Header: 'Time',
             accessor: (row) => formatTime(row.section.timeLocations),
-            // accessor: (_row) => {
-            //     console.log("_row=",_row);
-            //     return "TBD";
-            // },
             id: 'time',
         },
         {

--- a/frontend/src/main/components/Sections/SectionsTable.js
+++ b/frontend/src/main/components/Sections/SectionsTable.js
@@ -45,6 +45,10 @@ export default function SectionsTable({ sections }) {
         {
             Header: 'Time',
             accessor: (row) => formatTime(row.section.timeLocations),
+            // accessor: (_row) => {
+            //     console.log("_row=",_row);
+            //     return "TBD";
+            // },
             id: 'time',
         },
         {

--- a/frontend/src/main/pages/SectionSearches/SectionSearchesIndexPage.js
+++ b/frontend/src/main/pages/SectionSearches/SectionSearchesIndexPage.js
@@ -1,15 +1,17 @@
+
 import { useState } from "react";
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
 import BasicCourseSearchForm from "main/components/BasicCourseSearch/BasicCourseSearchForm";
-import BasicCourseTable from "main/components/Courses/BasicCourseTable";
+import _BasicCourseTable from "main/components/Courses/BasicCourseTable";
 import { useBackendMutation } from "main/utils/useBackend";
+import SectionsTable from "main/components/Sections/SectionsTable";
 
-export default function HomePage() {
+export default function SectionSearchesIndexPage() {
   // Stryker disable next-line all : Can't test state because hook is internal
-  const [courseJSON, setCourseJSON] = useState([]);
+  const [sectionJSON, setSectionJSON] = useState([]);
 
   const objectToAxiosParams = (query) => ({
-    url: "/api/public/basicsearch",
+    url: "/api/sections/basicsearch",
     params: {
       qtr: query.quarter,
       dept: query.subject,
@@ -17,8 +19,9 @@ export default function HomePage() {
     },
   });
 
-  const onSuccess = (courses) => {
-    setCourseJSON(courses.classes);
+  const onSuccess = (section) => {
+    console.log()
+    setSectionJSON(section);
   };
 
   const mutation = useBackendMutation(
@@ -28,16 +31,16 @@ export default function HomePage() {
     []
   );
 
-  async function fetchBasicCourseJSON(_event, query) {
+  async function fetchBasicSectionJSON(_event, query) {
     mutation.mutate(query);
   }
 
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h5>Welcome to the UCSB Courses Search App!</h5>
-        <BasicCourseSearchForm fetchJSON={fetchBasicCourseJSON} />
-        <BasicCourseTable courses={courseJSON} />
+        <h5>Welcome to the UCSB Section Search App!</h5>
+        <BasicCourseSearchForm fetchJSON={fetchBasicSectionJSON} />
+        <SectionsTable sections={sectionJSON} />
       </div>
     </BasicLayout>
   );

--- a/frontend/src/main/utils/sectionUtils.js
+++ b/frontend/src/main/utils/sectionUtils.js
@@ -21,8 +21,8 @@ export const formatLocation = (timeLocationArray) => {
 export const formatDays = (timeLocationArray) => {
     let res = "";
     for (let index = 0; index < timeLocationArray.length; index++) {
-        res += `${timeLocationArray[index].days}`;
-        if (index + 1 < timeLocationArray.length) {
+        res += (timeLocationArray[index].days !== null) ? `${timeLocationArray[index].days}` : "";
+        if (index + 1 < timeLocationArray.length && timeLocationArray[index].days !== null) {
             res += `, `
         } 
     }

--- a/frontend/src/main/utils/timeUtils.js
+++ b/frontend/src/main/utils/timeUtils.js
@@ -1,5 +1,4 @@
 export const hhmmTohhmma = (HHMM) => {
-    try{
     var time = HHMM.split(':');
     var hours = Number(time[0]);
     var minutes = Number(time[1]);
@@ -23,10 +22,6 @@ export const hhmmTohhmma = (HHMM) => {
     timeValue += (hours >= 12) ? " PM" : " AM";  // get AM/PM
     
     return timeValue;
-    }
-    catch(error){
-        return null
-    }
 }
 
 export const convertToTimeRange = (time1, time2) => {

--- a/frontend/src/main/utils/timeUtils.js
+++ b/frontend/src/main/utils/timeUtils.js
@@ -1,4 +1,5 @@
 export const hhmmTohhmma = (HHMM) => {
+    try{
     var time = HHMM.split(':');
     var hours = Number(time[0]);
     var minutes = Number(time[1]);
@@ -20,10 +21,14 @@ export const hhmmTohhmma = (HHMM) => {
     
     timeValue += (minutes < 10) ? ":0" + minutes : ":" + minutes;  // get minutes
     timeValue += (hours >= 12) ? " PM" : " AM";  // get AM/PM
-
+    
     return timeValue;
+    }
+    catch(error){
+        return null
+    }
 }
 
 export const convertToTimeRange = (time1, time2) => {
-    return `${time1} - ${time2}`
+    return (time1 !== null && time2 !== null) ? `${time1} - ${time2}` : "";
 }

--- a/frontend/src/stories/pages/HomePage/SectionSearches/SectionSearchesIndexPage.stories.js
+++ b/frontend/src/stories/pages/HomePage/SectionSearches/SectionSearchesIndexPage.stories.js
@@ -1,0 +1,12 @@
+import React from 'react';
+
+import SectionSearchesIndexpage from "main/pages/SectionSearches/SectionSearchesIndexPage";
+
+export default {
+    title: 'pages/SectionSearches/SectionSearchesIndexPage',
+    component: SectionSearchesIndexpage
+};
+
+const Template = () => <SectionSearchesIndexpage />;
+
+export const Default = Template.bind({});

--- a/frontend/src/tests/components/Nav/AppNavbar.test.js
+++ b/frontend/src/tests/components/Nav/AppNavbar.test.js
@@ -149,4 +149,27 @@ describe("AppNavbar tests", () => {
         expect(await screen.findByTestId("appnavbar-personalschedules-list")).toBeInTheDocument();
         expect(screen.getByTestId(/appnavbar-personalschedules-create/)).toBeInTheDocument();
     });
+
+    test("renders the Section Search menu correctly", async () => {
+        const currentUser = currentUserFixtures.userOnly;
+        const systemInfo = systemInfoFixtures.showingBoth;
+
+        const doLogin = jest.fn();
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <AppNavbar currentUser={currentUser} systemInfo={systemInfo} doLogin={doLogin} />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        expect(await screen.findByTestId("appnavbar-section-searches-dropdown")).toBeInTheDocument();
+        const dropdown = screen.getByTestId("appnavbar-section-searches-dropdown");
+        const aElement = dropdown.querySelector("a");
+        expect(aElement).toBeInTheDocument();
+        aElement?.click();
+
+        expect(await screen.findByTestId("appnavbar-section-searches-search")).toBeInTheDocument();
+    });
 });

--- a/frontend/src/tests/pages/SectionSearches/SectionSearchesIndexPage.test.js
+++ b/frontend/src/tests/pages/SectionSearches/SectionSearchesIndexPage.test.js
@@ -49,7 +49,7 @@ describe("Section Searches Index Page tests", () => {
     axiosMock.onGet("/api/UCSBSubjects/all").reply(200, allTheSubjects);
     axiosMock
       .onGet("/api/sections/basicsearch")
-      .reply(200, { classes:oneSection });
+      .reply(200, oneSection);
 
     render(
       <QueryClientProvider client={queryClient}>
@@ -85,6 +85,6 @@ describe("Section Searches Index Page tests", () => {
       level: "G",
     });
 
-    expect(screen.getByText("ECE       1A")).toBeInTheDocument();
+    expect(screen.getByText("ECE 1A")).toBeInTheDocument();
   });
 });

--- a/frontend/src/tests/pages/SectionSearches/SectionSearchesIndexPage.test.js
+++ b/frontend/src/tests/pages/SectionSearches/SectionSearchesIndexPage.test.js
@@ -1,71 +1,90 @@
-import { render } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
-import SectionSearchesIndexPage from "main/pages/SectionSearches/SectionSearchesIndexPage";
-
-
-import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
-import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
-import _mockConsole from "jest-mock-console";
+import userEvent from "@testing-library/user-event";
 
+import SectionSearchesIndexPage from "main/pages/SectionSearches/SectionSearchesIndexPage";
+import { oneSection } from "fixtures/sectionFixtures";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { allTheSubjects } from "fixtures/subjectFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 
 const mockToast = jest.fn();
-jest.mock('react-toastify', () => {
-    const originalModule = jest.requireActual('react-toastify');
-    return {
-        __esModule: true,
-        ...originalModule,
-        toast: (x) => mockToast(x)
-    };
+jest.mock("react-toastify", () => {
+  const originalModule = jest.requireActual("react-toastify");
+  return {
+    __esModule: true,
+    ...originalModule,
+    toast: (x) => mockToast(x),
+  };
 });
 
-describe("SectionSearchesIndexPage tests", () => {
+describe("Section Searches Index Page tests", () => {
+  const axiosMock = new AxiosMockAdapter(axios);
 
-    const axiosMock =new AxiosMockAdapter(axios);
+  beforeEach(() => {
+    axiosMock.resetHistory();
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.userOnly);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+  });
 
-    const setupUserOnly = () => {
-        axiosMock.reset();
-        axiosMock.resetHistory();
-        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
-        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
-    };
+  const queryClient = new QueryClient();
+  test("renders without crashing", () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <SectionSearchesIndexPage />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+  });
 
-    const setupAdminUser = () => {
-        axiosMock.reset();
-        axiosMock.resetHistory();
-        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.adminUser);
-        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
-    };
+  test("calls UCSB section search api correctly with 1 section response", async () => {
+    axiosMock.onGet("/api/UCSBSubjects/all").reply(200, allTheSubjects);
+    axiosMock
+      .onGet("/api/sections/basicsearch")
+      .reply(200, { classes:oneSection });
 
-    test("renders without crashing for regular user", () => {
-        setupUserOnly();
-        const queryClient = new QueryClient();
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <SectionSearchesIndexPage />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
 
-        render(
-            <QueryClientProvider client={queryClient}>
-                <MemoryRouter>
-                    <SectionSearchesIndexPage />
-                </MemoryRouter>
-            </QueryClientProvider>
-        );
+    const selectQuarter = screen.getByLabelText("Quarter");
+    userEvent.selectOptions(selectQuarter, "20222");
+    const selectSubject = screen.getByLabelText("Subject Area");
 
+    expect(await screen.findByLabelText("Subject Area")).toHaveTextContent("ANTH");
 
+    userEvent.selectOptions(selectSubject, "ANTH");
+    const selectLevel = screen.getByLabelText("Course Level");
+    userEvent.selectOptions(selectLevel, "G");
+
+    const submitButton = screen.getByText("Submit");
+    expect(submitButton).toBeInTheDocument();
+    userEvent.click(submitButton);
+
+    axiosMock.resetHistory();
+
+    await waitFor(() => {
+      expect(axiosMock.history.get.length).toBeGreaterThanOrEqual(1);
     });
 
-    test("renders without crashing for admin user", () => {
-        setupAdminUser();
-        const queryClient = new QueryClient();
-
-        render(
-            <QueryClientProvider client={queryClient}>
-                <MemoryRouter>
-                    <SectionSearchesIndexPage />
-                </MemoryRouter>
-            </QueryClientProvider>
-        );
-
-
+    expect(axiosMock.history.get[0].params).toEqual({
+      qtr: "20222",
+      dept: "ANTH",
+      level: "G",
     });
+
+    expect(screen.getByText("ECE       1A")).toBeInTheDocument();
+  });
 });

--- a/frontend/src/tests/pages/SectionSearches/SectionSearchesIndexPage.test.js
+++ b/frontend/src/tests/pages/SectionSearches/SectionSearchesIndexPage.test.js
@@ -1,0 +1,71 @@
+import { render } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import SectionSearchesIndexPage from "main/pages/SectionSearches/SectionSearchesIndexPage";
+
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+import _mockConsole from "jest-mock-console";
+
+
+const mockToast = jest.fn();
+jest.mock('react-toastify', () => {
+    const originalModule = jest.requireActual('react-toastify');
+    return {
+        __esModule: true,
+        ...originalModule,
+        toast: (x) => mockToast(x)
+    };
+});
+
+describe("SectionSearchesIndexPage tests", () => {
+
+    const axiosMock =new AxiosMockAdapter(axios);
+
+    const setupUserOnly = () => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    };
+
+    const setupAdminUser = () => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.adminUser);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    };
+
+    test("renders without crashing for regular user", () => {
+        setupUserOnly();
+        const queryClient = new QueryClient();
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <SectionSearchesIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+
+    });
+
+    test("renders without crashing for admin user", () => {
+        setupAdminUser();
+        const queryClient = new QueryClient();
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <SectionSearchesIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+
+    });
+});

--- a/frontend/src/tests/utils/sectionUtils.test.js
+++ b/frontend/src/tests/utils/sectionUtils.test.js
@@ -66,15 +66,15 @@ describe ("section utils tests", () => {
         expect(formatLocation(testTimeLocations)).toBe("LOC1 1, LOC2 2");
     }); 
 
-    test("formatDays test" , () => {
+    test("formatDays test 1" , () => {
         expect(formatDays(testTimeLocations)).toBe("M W, R F");
     });
     
-    test("formatDays test" , () => {
+    test("formatDays test 2" , () => {
         expect(formatDays(testTimeLocations1)).toBe("R F");
     });
 
-    test("formatTime test" , () => {
+    test("formatTime test 3" , () => {
         expect(formatTime(testTimeLocations)).toBe("3:30 PM - 4:45 PM, 10:30 AM - 11:45 AM");
     }); 
 

--- a/frontend/src/tests/utils/sectionUtils.test.js
+++ b/frontend/src/tests/utils/sectionUtils.test.js
@@ -19,6 +19,25 @@ const testTimeLocations = [
     }
 ]
 
+const testTimeLocations1 = [
+    {
+      "room": "1",
+      "building": "LOC1",
+      "roomCapacity": "90",
+      "days": null,
+      "beginTime": "15:30",
+      "endTime": "16:45"
+    },
+    {
+        "room": "2",
+        "building": "LOC2",
+        "roomCapacity": "90",
+        "days": "R F",
+        "beginTime": "10:30",
+        "endTime": "11:45"
+    }
+]
+
 const testInstructors = [
     {
       "instructor": "HESPANHA J P",
@@ -49,7 +68,11 @@ describe ("section utils tests", () => {
 
     test("formatDays test" , () => {
         expect(formatDays(testTimeLocations)).toBe("M W, R F");
-    }); 
+    });
+    
+    test("formatDays test" , () => {
+        expect(formatDays(testTimeLocations1)).toBe("R F");
+    });
 
     test("formatTime test" , () => {
         expect(formatTime(testTimeLocations)).toBe("3:30 PM - 4:45 PM, 10:30 AM - 11:45 AM");

--- a/frontend/src/tests/utils/timeUtils.test.js
+++ b/frontend/src/tests/utils/timeUtils.test.js
@@ -1,4 +1,4 @@
-import { hhmmTohhmma } from "main/utils/timeUtils";
+import { hhmmTohhmma, convertToTimeRange } from "main/utils/timeUtils.js"
   
 describe("time conversion tests", () => {
     
@@ -32,5 +32,24 @@ describe("time conversion tests", () => {
 
     test("hhmmTohhmma invalid minute test 2", () => {
         expect(() => { hhmmTohhmma("12:60"); }).toThrow("invalid minute param");
+    });
+})
+
+describe("time range conversion tests", () => {
+    
+    test("12:30 - 12:59", () => {
+        expect(convertToTimeRange("12:30","12:59")).toBe("12:30 - 12:59");
+    });
+
+    test("null - 12:59", () => {
+        expect(convertToTimeRange(null,"12:59")).toBe("");
+    });
+
+    test("null - null", () => {
+        expect(convertToTimeRange(null,null)).toBe("");
+    });
+
+    test("12:59 - null", () => {
+        expect(convertToTimeRange("12:59",null)).toBe("");
     });
 })

--- a/frontend/src/tests/utils/timeUtils.test.js
+++ b/frontend/src/tests/utils/timeUtils.test.js
@@ -1,4 +1,4 @@
-import { hhmmTohhmma, convertToTimeRange } from "main/utils/timeUtils.js"
+import { hhmmTohhmma, convertToTimeRange } from "main/utils/timeUtils";
   
 describe("time conversion tests", () => {
     


### PR DESCRIPTION
# Overview

This PR adds the new section search index page so that users can get section results based on the inputted queries and have them displayed on a section table.

# Issues Addressed

#10 #28 
**Added** Sectionsearch to navbar and adding navbar test(passed) for sectionsearch.
**Added** page for sectionsearch and test for it (passed).
**Added** Storybook for SectionSearchesIndex page and successfully built. 
**Added** sectionsearch to App.js and test for it (passed). 
**Added** test for "convertToTimeRange" function in timeUtils and passed. 
**Added** test for "formatDays" with null case. 

# Storybook 

[Section Index Page](https://ucsb-cs156-s22.github.io/s22-4pm-courses-docs-qa/storybook-qa/Harry-Section-Navbar/?path=%2Fstory%2Fpages-sectionsearches-sectionsearchesindexpage--default)

[Nav Bar](https://ucsb-cs156-s22.github.io/s22-4pm-courses-docs-qa/storybook-qa/Harry-Section-Navbar/?path=%2Fstory%2Fcomponents-nav-appnavbar--basic-logged-in-admin-user)

# Details

## NEW Section Index Page

![Sectionsearch Index page story](https://user-images.githubusercontent.com/86387032/171506453-095e3c18-7cf1-4b80-86e4-0332177aebfd.png)

![Sectionsearch](https://user-images.githubusercontent.com/86387032/171506431-ac83eadc-c9b2-4a0c-8507-8a1fc3177b83.png)

# Test Plan (for interactive testing) 

1. Run the backend and frontend on local machine
2. Proceed to section search index page via the navbar
3. Make a new search and verify that results appear on the section table