### PR TITLE
4pm-2 - kt - endpt to get psid sections formatted acc to 4pm-1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,11 @@
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.json</groupId>
+            <artifactId>json</artifactId>
+            <version>20090211</version>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-oauth2-client</artifactId>
         </dependency>

--- a/src/main/java/edu/ucsb/cs156/courses/controllers/PersonalCoursesController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/PersonalCoursesController.java
@@ -1,0 +1,314 @@
+package edu.ucsb.cs156.courses.controllers;
+
+import edu.ucsb.cs156.courses.documents.Course;
+import edu.ucsb.cs156.courses.documents.FormattedSection;
+import edu.ucsb.cs156.courses.documents.CourseInfo;
+import edu.ucsb.cs156.courses.documents.SectionInfo;
+import edu.ucsb.cs156.courses.documents.TimeLocation;
+import edu.ucsb.cs156.courses.documents.Instructor;
+import edu.ucsb.cs156.courses.entities.Courses;
+import edu.ucsb.cs156.courses.entities.User;
+import edu.ucsb.cs156.courses.errors.EntityNotFoundException;
+import edu.ucsb.cs156.courses.models.CurrentUser;
+import edu.ucsb.cs156.courses.repositories.CoursesRepository;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import lombok.extern.slf4j.Slf4j;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import org.json.*;
+import java.util.List;
+import java.util.ArrayList;
+
+import javax.validation.Valid;
+import java.util.Optional;
+import java.net.*;
+import java.io.InputStream;
+
+import java.util.Scanner;
+
+import edu.ucsb.cs156.courses.entities.PersonalSchedule;
+import edu.ucsb.cs156.courses.repositories.PersonalScheduleRepository;
+
+@Api(description = "Courses")
+@RequestMapping("/api/courses")
+@RestController
+@Slf4j
+public class PersonalCoursesController extends ApiController {
+
+    @Autowired
+    private CoursesRepository coursesRepository;
+    @Autowired
+    private PersonalScheduleRepository personalScheduleRepository;
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @ApiOperation(value = "List all courses for any specified psId (admin)")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @GetMapping(value="/admin/psid/sections/all",produces = "application/json")
+    public Iterable<Course> allSectionsForPsId_Admin(
+            @ApiParam("psId") @RequestParam Long psId) {
+        Iterable<Courses> courses = coursesRepository.findAllByPsId(psId);
+        PersonalSchedule ps = personalScheduleRepository.findById(psId)
+          .orElseThrow(() -> new EntityNotFoundException(PersonalSchedule.class, psId));
+        String qtr = ps.getQuarter();
+        JSONArray returnSections = new JSONArray();
+        List<Course> listSec = new ArrayList();
+        for(Courses crs: courses){ // are we still getting quarter as an input?
+            try{
+                URL url = new URL("https://api.ucsb.edu/academics/curriculums/v3/classsection/" + qtr + "/" + crs.getEnrollCd());
+                HttpURLConnection c = (HttpURLConnection) url.openConnection();
+                c.setRequestProperty("accept", "application/json");
+                c.setRequestProperty("ucsb-api-version", "3.0");
+                c.setRequestProperty("ucsb-api-key", "vb8mlvnaJeqYiAGXP1qa5INS4noghlAR");
+                InputStream is = c.getInputStream();
+                Scanner s = new Scanner(is);
+                String responseBody = s.useDelimiter("\\A").next();
+            
+                Course course = objectMapper.readValue(responseBody, Course.class);
+                listSec.add(course);
+                continue;
+
+            }
+            catch (Exception e){
+                System.out.println("Exception " + e);
+            }
+        }
+        //JSONArray not returning so until then returning as String array
+        String[] arr=new String[returnSections.length()];
+        for(int i=0; i<arr.length; i++) {
+            arr[i]=returnSections.optString(i);
+        }
+        return listSec; 
+    }
+
+    @ApiOperation(value = "List all courses for a specified psId if it belongs to the user")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping(value="/fdspsid/sections/all",produces = "application/json")
+    public Iterable<FormattedSection> allSectionsForPsId(
+            @ApiParam("psId") @RequestParam Long psId) {
+        User currentUser = getCurrentUser().getUser();
+        Iterable<Courses> courses = coursesRepository.findAllByPsIdAndUser(psId, currentUser);
+        PersonalSchedule ps = personalScheduleRepository.findByIdAndUser(psId, currentUser)
+          .orElseThrow(() -> new EntityNotFoundException(PersonalSchedule.class, psId));
+        String qtr = ps.getQuarter();
+        JSONArray returnSections = new JSONArray();
+        List<Course> listSec = new ArrayList();
+        List<FormattedSection> formSecs = new ArrayList();
+        List<String> jsons = new ArrayList();
+        for(Courses crs: courses){ // are we still getting quarter as an input?
+            try{
+                URL url = new URL("https://api.ucsb.edu/academics/curriculums/v3/classsection/" + qtr + "/" + crs.getEnrollCd());
+                HttpURLConnection c = (HttpURLConnection) url.openConnection();
+                c.setRequestProperty("accept", "application/json");
+                c.setRequestProperty("ucsb-api-version", "3.0");
+                c.setRequestProperty("ucsb-api-key", "vb8mlvnaJeqYiAGXP1qa5INS4noghlAR");
+                InputStream is = c.getInputStream();
+                Scanner s = new Scanner(is);
+                String responseBody = s.useDelimiter("\\A").next();
+            
+                Course course = objectMapper.readValue(responseBody, Course.class);
+                listSec.add(course);
+
+                //trying to map a formatted section
+                
+                CourseInfo crsInfo = objectMapper.readValue(responseBody, CourseInfo.class);
+                JSONObject jsonObject = new JSONObject(responseBody);
+                JSONArray sectionArr = jsonObject.getJSONArray("classSections");
+                JSONObject obj=sectionArr.getJSONObject(0);
+                String sectionArrStr = obj.toString();
+                
+                JSONArray timeLocArr = obj.getJSONArray("timeLocations");
+                JSONObject obj2=timeLocArr.getJSONObject(0);
+                String timeLocArrStr = obj2.toString();
+                TimeLocation timeLocInfo = objectMapper.readValue(timeLocArrStr, TimeLocation.class);
+
+                JSONArray instrArr = obj.getJSONArray("instructors");
+                JSONObject obj3 = instrArr.getJSONObject(0);
+                String instrArrStr = obj3.toString();
+                Instructor instrInfo = objectMapper.readValue(instrArrStr, Instructor.class);
+
+                //SectionInfo secInfo = new SectionInfo(null, null, null, timeLocInfo, instrInfo);
+                SectionInfo secInfo = objectMapper.readValue(sectionArrStr, SectionInfo.class);
+
+                FormattedSection fSec = new FormattedSection(crsInfo, secInfo);
+                formSecs.add(fSec);
+                jsons.add(timeLocArrStr);
+                continue;
+
+            }
+            catch (Exception e){
+                System.out.println("Exception " + e);
+            }
+        }
+        //JSONArray not returning so until then returning as String array
+        String[] arr=new String[returnSections.length()];
+        for(int i=0; i<arr.length; i++) {
+            arr[i]=returnSections.optString(i);
+        }
+
+        return formSecs;   
+        //return jsons;
+    }
+
+
+
+    // in sachen's pull request
+    @ApiOperation(value = "List all courses (admin)")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @GetMapping("/admin/all")
+    public Iterable<Courses> allUsersCourses() {
+        Iterable<Courses> courses = coursesRepository.findAll();
+        return courses;
+    }
+
+    @ApiOperation(value = "List all courses (user)")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("/user/all")
+    public Iterable<Courses> thisUsersCourses() {
+        CurrentUser currentUser = getCurrentUser();
+        Iterable<Courses> courses = coursesRepository.findAllByUserId(currentUser.getUser().getId());
+        return courses;
+    }
+
+    @ApiOperation(value = "List all courses for a specified psId (admin)")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @GetMapping("/admin/psid/all")
+    public Iterable<Courses> allCoursesForPsId(
+            @ApiParam("psId") @RequestParam Long psId) {
+        Iterable<Courses> courses = coursesRepository.findAllByPsId(psId);
+        return courses;
+    }
+
+    @ApiOperation(value = "List all courses for a specified psId (user)")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("/user/psid/all")
+    public Iterable<Courses> thisUsersCoursesForPsId(
+            @ApiParam("psId") @RequestParam Long psId) {
+        User currentUser = getCurrentUser().getUser();
+        Iterable<Courses> courses = coursesRepository.findAllByPsIdAndUser(psId, currentUser);
+        return courses;
+    }
+
+    @ApiOperation(value = "Get a single course (admin)")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @GetMapping("/admin")
+    public Courses getCourseById_admin(
+            @ApiParam("id") @RequestParam Long id) {
+        Courses courses = coursesRepository.findById(id)
+          .orElseThrow(() -> new EntityNotFoundException(Courses.class, id));
+
+        return courses;
+    }
+
+    @ApiOperation(value = "Get a single course (user)")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("/user")
+    public Courses getCourseById(
+            @ApiParam("id") @RequestParam Long id) {
+        User currentUser = getCurrentUser().getUser();
+        Courses courses = coursesRepository.findByIdAndUser(id, currentUser)
+            .orElseThrow(() -> new EntityNotFoundException(Courses.class, id));
+
+        return courses;
+    }
+
+
+    @ApiOperation(value = "Create a new course (user)")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @PostMapping("/post")
+    public Courses postCourses(
+            @ApiParam("enrollCd") @RequestParam String enrollCd,
+            @ApiParam("psId") @RequestParam Long psId) {
+        CurrentUser currentUser = getCurrentUser();
+        log.info("currentUser={}", currentUser);
+        // Check if psId exists
+        PersonalSchedule checkPsId = personalScheduleRepository.findByIdAndUser(psId, currentUser.getUser())
+            .orElseThrow(() -> new EntityNotFoundException(PersonalSchedule.class, psId));
+        // Check if enrollCd exists
+        
+
+        Courses courses = new Courses();
+        courses.setUser(currentUser.getUser());
+        courses.setEnrollCd(enrollCd);
+        courses.setPsId(psId);
+        Courses savedCourses = coursesRepository.save(courses);
+        return savedCourses;
+    }
+
+    @ApiOperation(value = "Delete a course (admin)")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @DeleteMapping("/admin")
+    public Object deleteCourses_Admin(
+            @ApiParam("id") @RequestParam Long id) {
+              Courses courses = coursesRepository.findById(id)
+          .orElseThrow(() -> new EntityNotFoundException(Courses.class, id));
+
+          coursesRepository.delete(courses);
+
+        return genericMessage("Courses with id %s deleted".formatted(id));
+    }
+
+    @ApiOperation(value = "Delete a course (user)")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @DeleteMapping("/user")
+    public Object deleteCourses(
+            @ApiParam("id") @RequestParam Long id) {
+        User currentUser = getCurrentUser().getUser();
+        Courses courses = coursesRepository.findByIdAndUser(id, currentUser)
+          .orElseThrow(() -> new EntityNotFoundException(Courses.class, id));
+        coursesRepository.delete(courses);
+        return genericMessage("Courses with id %s deleted".formatted(id));
+    }
+
+    @ApiOperation(value = "Update a single Course (admin)")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PutMapping("/admin")
+    public Courses putCourseById_admin(
+            @ApiParam("id") @RequestParam Long id,
+            @RequestBody @Valid Courses incomingCourses) {
+              Courses courses = coursesRepository.findById(id)
+          .orElseThrow(() -> new EntityNotFoundException(Courses.class, id));
+
+          courses.setEnrollCd(incomingCourses.getEnrollCd());
+          courses.setPsId(incomingCourses.getPsId());
+
+        coursesRepository.save(courses);
+
+        return courses;
+    }
+
+    @ApiOperation(value = "Update a single course (user)")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @PutMapping("/user")
+    public Courses putCoursesById(
+            @ApiParam("id") @RequestParam Long id,
+            @RequestBody @Valid Courses incomingCourses) {
+        User currentUser = getCurrentUser().getUser();
+        Courses courses = coursesRepository.findByIdAndUser(id, currentUser)
+          .orElseThrow(() -> new EntityNotFoundException(Courses.class, id));
+
+        courses.setEnrollCd(incomingCourses.getEnrollCd());
+        courses.setPsId(incomingCourses.getPsId());
+
+        coursesRepository.save(courses);
+
+        return courses;
+    }
+}

--- a/src/main/java/edu/ucsb/cs156/courses/documents/FormattedInstructor.java
+++ b/src/main/java/edu/ucsb/cs156/courses/documents/FormattedInstructor.java
@@ -1,0 +1,15 @@
+package edu.ucsb.cs156.courses.documents;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class FormattedInstructor {
+    private String instructor;
+}

--- a/src/main/java/edu/ucsb/cs156/courses/documents/FormattedSection.java
+++ b/src/main/java/edu/ucsb/cs156/courses/documents/FormattedSection.java
@@ -1,0 +1,17 @@
+package edu.ucsb.cs156.courses.documents;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class FormattedSection {
+    private CourseInfo courseInfo;
+    private SectionInfo sectionInfo;
+}

--- a/src/main/java/edu/ucsb/cs156/courses/documents/FormattedTimeLocation.java
+++ b/src/main/java/edu/ucsb/cs156/courses/documents/FormattedTimeLocation.java
@@ -1,0 +1,18 @@
+package edu.ucsb.cs156.courses.documents;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class FormattedTimeLocation {
+    private String room;
+    private String building;
+    private String days; 
+    private String beginTime; 
+    private String endTime;
+}

--- a/src/main/java/edu/ucsb/cs156/courses/documents/SectionInfo.java
+++ b/src/main/java/edu/ucsb/cs156/courses/documents/SectionInfo.java
@@ -1,0 +1,22 @@
+package edu.ucsb.cs156.courses.documents;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SectionInfo {
+    private String enrollCode;
+    private String enrolledTotal;
+    private String maxEnroll;
+    // in timeloc
+    private List<FormattedTimeLocation> timeLocations;
+    // in instr
+    private List<FormattedInstructor> instructors;
+}

--- a/src/main/java/edu/ucsb/cs156/courses/entities/Courses.java
+++ b/src/main/java/edu/ucsb/cs156/courses/entities/Courses.java
@@ -4,6 +4,8 @@ import javax.persistence.Entity;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.GeneratedValue;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
 
 
 import lombok.Data;
@@ -21,7 +23,9 @@ public class Courses {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private long id;
 
+  @ManyToOne
+  @JoinColumn(name = "user_id")
+  private User user;
   private String enrollCd;
-  private String psId;
-  private String quarter;
+  private long psId;
 }

--- a/src/main/java/edu/ucsb/cs156/courses/repositories/CoursesRepository.java
+++ b/src/main/java/edu/ucsb/cs156/courses/repositories/CoursesRepository.java
@@ -1,10 +1,20 @@
 package edu.ucsb.cs156.courses.repositories;
 
 import edu.ucsb.cs156.courses.entities.Courses;
+import edu.ucsb.cs156.courses.entities.User;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
+
 @Repository
 public interface CoursesRepository extends CrudRepository<Courses, Long> {
-  
+  Optional<Courses> findByPsId(Long psId);
+  Optional<Courses> findById(Long id);
+  Optional<Courses> findByIdAndUser(long id, User user);
+
+  Iterable<Courses> findAllByPsId(Long psId);
+  Iterable<Courses> findAllByPsIdAndUser(Long psId, User user);
+  Iterable<Courses> findAllByUserId(Long user_id);
 }

--- a/src/main/java/edu/ucsb/cs156/courses/repositories/PersonalScheduleRepository.java
+++ b/src/main/java/edu/ucsb/cs156/courses/repositories/PersonalScheduleRepository.java
@@ -12,4 +12,5 @@ import java.util.Optional;
 public interface PersonalScheduleRepository extends CrudRepository<PersonalSchedule, Long> {
   Optional<PersonalSchedule> findByIdAndUser(long id, User user);
   Iterable<PersonalSchedule> findAllByUserId(Long user_id);
+  Optional<PersonalSchedule> findById(long id);
 }

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/PersonalCoursesControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/PersonalCoursesControllerTests.java
@@ -1,0 +1,109 @@
+package edu.ucsb.cs156.courses.controllers;
+
+import edu.ucsb.cs156.courses.documents.Course;
+import edu.ucsb.cs156.courses.repositories.UserRepository;
+import edu.ucsb.cs156.courses.testconfig.TestConfig;
+import edu.ucsb.cs156.courses.ControllerTestCase;
+import edu.ucsb.cs156.courses.entities.PersonalSchedule;
+import edu.ucsb.cs156.courses.entities.Courses;
+import edu.ucsb.cs156.courses.entities.User;
+import edu.ucsb.cs156.courses.repositories.PersonalScheduleRepository;
+import edu.ucsb.cs156.courses.repositories.CoursesRepository;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MvcResult;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@WebMvcTest(controllers = PersonalCoursesController.class)
+@Import(TestConfig.class)
+public class PersonalCoursesControllerTests extends ControllerTestCase {
+
+    @MockBean
+    PersonalScheduleRepository personalscheduleRepository;
+
+    @MockBean
+    UserRepository userRepository;
+
+    @MockBean
+    CoursesRepository coursesRepository;
+
+    // Authorization tests for /api/personalschedules/admin/psid/sections/all
+
+    @Test
+    public void api_psid_sections_admin_all__logged_out__returns_403() throws Exception {
+        mockMvc.perform(get("/api/courses/admin/psid/sections/all?psId=1"))
+                .andExpect(status().is(403));
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void api_psid_sections_admin__user_logged_in__returns_403() throws Exception {
+        mockMvc.perform(get("/api/courses/admin/psid/sections/all?psId=1"))
+                .andExpect(status().is(403));
+    }
+
+    // tests with mocks for database actions
+    @WithMockUser(roles = { "ADMIN" })
+    @Test
+    public void api_psid_sections_admin__user_logged_in__returns_a_course_that_exists() throws Exception {
+        // arrange
+        User u = currentUserService.getCurrentUser().getUser();
+        PersonalSchedule personalschedule1 = PersonalSchedule.builder().name("Name 1").description("Description 1").quarter("20221").user(u).id(1L).build();
+        when(personalscheduleRepository.findByIdAndUser(eq(1L), eq(u))).thenReturn(Optional.of(personalschedule1));
+        Courses course1 = Courses.builder().id(1L).user(u).enrollCd("59501").psId(1L).build();
+        when(coursesRepository.findByIdAndUser(eq(1L), eq(u))).thenReturn(Optional.of(course1));
+        // act
+        MvcResult response = mockMvc.perform(get("/api/courses/admin/psid/sections/all?psId=1"))
+                .andExpect(status().isOk()).andReturn();
+        //MvcResult response = mockMvc.perform(get("/api/courses/admin/psid/sections/all?psId=1"))
+        //        .andExpect(status().isOk()).andReturn();
+        // assert
+        verify(personalscheduleRepository, times(1)).findByIdAndUser(1L, u);
+        verify(coursesRepository, times(1)).findByIdAndUser(1L, u);
+        
+        //Course course = objectMapper.readValue(responseBody, Course.class);
+        //String expectedJson = 
+
+
+
+
+        /*
+        // arrange
+
+        User u = currentUserService.getCurrentUser().getUser();
+        PersonalSchedule personalschedule1 = PersonalSchedule.builder().name("Name 1").description("Description 1").quarter("20221").user(u).id(7L).build();
+        when(personalscheduleRepository.findByIdAndUser(eq(7L), eq(u))).thenReturn(Optional.of(personalschedule1));
+
+        // act
+        MvcResult response = mockMvc.perform(get("/api/personalschedules?id=7"))
+                .andExpect(status().isOk()).andReturn();
+
+        // assert
+
+        verify(personalscheduleRepository, times(1)).findByIdAndUser(7L, u);
+        String expectedJson = mapper.writeValueAsString(personalschedule1);
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(expectedJson, responseString);*/
+    }
+
+}

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/PersonalCoursesControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/PersonalCoursesControllerTests.java
@@ -66,44 +66,16 @@ public class PersonalCoursesControllerTests extends ControllerTestCase {
     @WithMockUser(roles = { "ADMIN" })
     @Test
     public void api_psid_sections_admin__user_logged_in__returns_a_course_that_exists() throws Exception {
-        // arrange
         User u = currentUserService.getCurrentUser().getUser();
         PersonalSchedule personalschedule1 = PersonalSchedule.builder().name("Name 1").description("Description 1").quarter("20221").user(u).id(1L).build();
         when(personalscheduleRepository.findByIdAndUser(eq(1L), eq(u))).thenReturn(Optional.of(personalschedule1));
         Courses course1 = Courses.builder().id(1L).user(u).enrollCd("59501").psId(1L).build();
         when(coursesRepository.findByIdAndUser(eq(1L), eq(u))).thenReturn(Optional.of(course1));
-        // act
         MvcResult response = mockMvc.perform(get("/api/courses/admin/psid/sections/all?psId=1"))
                 .andExpect(status().isOk()).andReturn();
-        //MvcResult response = mockMvc.perform(get("/api/courses/admin/psid/sections/all?psId=1"))
-        //        .andExpect(status().isOk()).andReturn();
-        // assert
         verify(personalscheduleRepository, times(1)).findByIdAndUser(1L, u);
         verify(coursesRepository, times(1)).findByIdAndUser(1L, u);
         
-        //Course course = objectMapper.readValue(responseBody, Course.class);
-        //String expectedJson = 
-
-
-
-
-        /*
-        // arrange
-
-        User u = currentUserService.getCurrentUser().getUser();
-        PersonalSchedule personalschedule1 = PersonalSchedule.builder().name("Name 1").description("Description 1").quarter("20221").user(u).id(7L).build();
-        when(personalscheduleRepository.findByIdAndUser(eq(7L), eq(u))).thenReturn(Optional.of(personalschedule1));
-
-        // act
-        MvcResult response = mockMvc.perform(get("/api/personalschedules?id=7"))
-                .andExpect(status().isOk()).andReturn();
-
-        // assert
-
-        verify(personalscheduleRepository, times(1)).findByIdAndUser(7L, u);
-        String expectedJson = mapper.writeValueAsString(personalschedule1);
-        String responseString = response.getResponse().getContentAsString();
-        assertEquals(expectedJson, responseString);*/
     }
 
 }


### PR DESCRIPTION
Note: Tests are still in progress, and I will update this message when they are clear. For now, the endpoint works on Swagger, and a number of tests are passing.

In this PR, we modify the personalCourses controller to retrieve the section data using psIds, formatted following 4pm-1's guidelines. This involved adding documents for FormattedSection, FormattedTimeLocation, and FormattedInstructor, as well as implementing mapper to correctly populate the structure.
Closes #22 
<img width="959" alt="Screen Shot 2022-06-01 at 10 52 35 PM" src="https://user-images.githubusercontent.com/34698996/171562101-24b19a4a-9ede-4635-8bc8-4cce1c547b1e.png">

