### PR TITLE
mh-changed error messages

### DIFF
--- a/src/main/java/edu/ucsb/cs156/courses/services/UCSBCurriculumService.java
+++ b/src/main/java/edu/ucsb/cs156/courses/services/UCSBCurriculumService.java
@@ -1,6 +1,5 @@
 package edu.ucsb.cs156.courses.services;
 
-import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;

--- a/src/main/java/edu/ucsb/cs156/courses/services/UCSBCurriculumService.java
+++ b/src/main/java/edu/ucsb/cs156/courses/services/UCSBCurriculumService.java
@@ -1,5 +1,6 @@
 package edu.ucsb.cs156.courses.services;
 
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -174,7 +175,13 @@ public class UCSBCurriculumService {
             statusCode = re.getStatusCode();
             retVal = re.getBody();
         } catch (HttpClientErrorException e) {
-            retVal = "{\"error\": \"401: Unauthorized\"}";
+            if(!quarter.matches("\\d{4}[1-4]") ){
+                retVal = "{\"error\": \"Quarter must be in YYYYQ format.\"}";
+            }
+            else{
+                retVal = "{\"error\": \"401: Unauthorized\"}";
+            }
+            
         }
 
         if(retVal.equals("null")){


### PR DESCRIPTION
# Overview

Small correction to PR #36 . Had to fix error messages when inputting an invalid enroll code. Now added error message for quarter not in YYYYQ format. 



# Details
If the quarter isn't in YYYYQ format, gives error message
![image](https://user-images.githubusercontent.com/59808746/172024438-f25e1b42-c96a-4fe0-bbef-3abcfb7b11a1.png)


