### PR TITLE
s22-4pm-2 Eren - add endpoint returns sections for psId

### DIFF
--- a/src/main/java/edu/ucsb/cs156/courses/controllers/PersonalSchedulesController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/PersonalSchedulesController.java
@@ -1,10 +1,12 @@
 package edu.ucsb.cs156.courses.controllers;
 
 import edu.ucsb.cs156.courses.entities.PersonalSchedule;
+import edu.ucsb.cs156.courses.entities.PSCourse;
 import edu.ucsb.cs156.courses.entities.User;
 import edu.ucsb.cs156.courses.errors.EntityNotFoundException;
 import edu.ucsb.cs156.courses.models.CurrentUser;
 import edu.ucsb.cs156.courses.repositories.PersonalScheduleRepository;
+import edu.ucsb.cs156.courses.repositories.PSCourseRepository;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
@@ -37,7 +39,7 @@ public class PersonalSchedulesController extends ApiController {
 
     @Autowired
     PersonalScheduleRepository personalscheduleRepository;
-
+    PSCourseRepository pscourseRepository;
     @ApiOperation(value = "List all personal schedules")
     @PreAuthorize("hasRole('ROLE_ADMIN')")
     @GetMapping("/admin/all")

--- a/src/main/java/edu/ucsb/cs156/courses/controllers/SectionController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/SectionController.java
@@ -1,0 +1,64 @@
+package edu.ucsb.cs156.courses.controllers;
+
+import edu.ucsb.cs156.courses.documents.CoursePage;
+import edu.ucsb.cs156.courses.entities.PersonalSchedule;
+import edu.ucsb.cs156.courses.entities.PSCourse;
+import edu.ucsb.cs156.courses.entities.User;
+import edu.ucsb.cs156.courses.errors.EntityNotFoundException;
+import edu.ucsb.cs156.courses.models.CurrentUser;
+import edu.ucsb.cs156.courses.repositories.PSCourseRepository;
+import edu.ucsb.cs156.courses.services.UCSBCurriculumService;
+import edu.ucsb.cs156.courses.documents.ConvertedSection;
+import edu.ucsb.cs156.courses.documents.CourseInfo;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import lombok.extern.slf4j.Slf4j;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import java.util.ArrayList;
+import java.util.List;
+import javax.validation.Valid;
+import java.util.Optional;
+
+@Api(description = "Sections")
+@RequestMapping("/api/sections")
+@RestController
+@Slf4j
+public class SectionController extends ApiController {
+
+    @Autowired
+    PSCourseRepository pscourseRepository;
+
+    @Autowired
+    UCSBCurriculumService ucsbCurriculumService;
+
+
+    @ApiOperation(value = "List sections in a personal schedule")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping(value = "/getsections", produces = "application/json")
+    public Iterable<CourseInfo> getSectionsByPersonalScheduleID (
+          @ApiParam("personal schedule id") @RequestParam Long psId) throws JsonProcessingException {
+
+        ArrayList<CourseInfo> convertedSections = new ArrayList<CourseInfo>();
+        Iterable<PSCourse> pscourse = pscourseRepository.findAllByPsId(psId);
+        for (PSCourse pc: pscourse) {
+            List<CourseInfo> convertedSection = ucsbCurriculumService.getConvertedSectionsByQuarterAndEnroll(pc.getQuarter(), pc.getEnrollCd());
+            convertedSections.addAll(convertedSection);
+        }
+
+        return convertedSections;
+    }
+}

--- a/src/main/java/edu/ucsb/cs156/courses/documents/Course.java
+++ b/src/main/java/edu/ucsb/cs156/courses/documents/Course.java
@@ -23,8 +23,20 @@ public class Course {
     private String quarter;
     private String courseId;
     private String title;
+    private int contactHours;
     private String description;
-    private List<Section> classSections;
+    private String college;
+    private String objLevelCode;
+    private String subjectArea;
+    private int unitsFixed;
+    private int unitsVariableHigh;
+    private int unitsVariableLow;
+    private boolean delayedSectioning;
+    private boolean inProgressCourse;
+    private String gradingOption;
+    private String instructionType;
+    private boolean onLineCourse;
+    private String deptCode;
     private List<GeneralEducation> generalEducation;
-    private FinalExam finalExam;
+    private List<Section> classSections;
 }

--- a/src/main/java/edu/ucsb/cs156/courses/documents/CourseInfo.java
+++ b/src/main/java/edu/ucsb/cs156/courses/documents/CourseInfo.java
@@ -1,5 +1,6 @@
 package edu.ucsb.cs156.courses.documents;
 
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -18,5 +19,20 @@ public class CourseInfo {
     private String quarter;
     private String courseId;
     private String title;
+    private int contactHours;
     private String description;
+    private String college;
+    private String objLevelCode;
+    private String subjectArea;
+    private int unitsFixed;
+    private int unitsVariableHigh;
+    private int unitsVariableLow;
+    private boolean delayedSectioning;
+    private boolean inProgressCourse;
+    private String gradingOption;
+    private String instructionType;
+    private boolean onLineCourse;
+    private String deptCode;
+    private List<GeneralEducation> generalEducation;
+    private List<Section> classSections;
 }

--- a/src/main/java/edu/ucsb/cs156/courses/documents/CoursePage.java
+++ b/src/main/java/edu/ucsb/cs156/courses/documents/CoursePage.java
@@ -77,4 +77,34 @@ public class CoursePage {
         return result;
     }
 
+    public List<CourseInfo> convertedSectionsInfo() {
+
+	List<CourseInfo> result = new ArrayList<CourseInfo>();
+
+	for (Course c : this.getClasses()) {
+	    for (Section section : c.getClassSections()) {
+		CourseInfo courseInfo = CourseInfo.builder()
+                        .quarter(c.getQuarter())
+                        .courseId(c.getCourseId())
+                        .title(c.getTitle())
+                        .contactHours(c.getContactHours())
+                        .description(c.getDescription())
+                        .college(c.getCollege())
+                        .objLevelCode(c.getObjLevelCode())
+                        .subjectArea(c.getSubjectArea())
+                        .unitsFixed(c.getUnitsFixed())
+                        .unitsVariableHigh(c.getUnitsVariableHigh())
+                        .unitsVariableLow(c.getUnitsVariableLow())
+                        .gradingOption(c.getGradingOption())
+                        .instructionType(c.getInstructionType())
+                        .deptCode(c.getDeptCode())
+                        .generalEducation(c.getGeneralEducation())
+                        .classSections(c.getClassSections())
+                        .build();
+                result.add(courseInfo);
+
+            }
+        }
+        return result;
+    }
 }

--- a/src/main/java/edu/ucsb/cs156/courses/entities/PSCourse.java
+++ b/src/main/java/edu/ucsb/cs156/courses/entities/PSCourse.java
@@ -19,13 +19,13 @@ import lombok.Builder;
 @Builder
 @Entity(name = "courses")
 public class PSCourse {
-  @Id
-  @GeneratedValue(strategy = GenerationType.IDENTITY)
-  private long id;
-
-  @ManyToOne
-  @JoinColumn(name = "user_id")
-  private User user;
-  private String enrollCd;
-  private long psId;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+    private String enrollCd;
+    private long psId;
+    private String quarter;
 }

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/SectionControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/SectionControllerTests.java
@@ -1,0 +1,89 @@
+package edu.ucsb.cs156.courses.controllers;
+
+import edu.ucsb.cs156.courses.config.SecurityConfig;
+import edu.ucsb.cs156.courses.ControllerTestCase;
+import edu.ucsb.cs156.courses.documents.CourseInfo;
+import edu.ucsb.cs156.courses.documents.CoursePage;
+import edu.ucsb.cs156.courses.documents.CoursePageFixtures;
+import edu.ucsb.cs156.courses.documents.ConvertedSection;
+import edu.ucsb.cs156.courses.entities.PSCourse;
+import edu.ucsb.cs156.courses.repositories.PSCourseRepository;
+import edu.ucsb.cs156.courses.repositories.UserRepository;
+import edu.ucsb.cs156.courses.services.UCSBCurriculumService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Arrays;
+
+@WebMvcTest(value = SectionController.class)
+@Import(SecurityConfig.class)
+public class SectionControllerTests extends ControllerTestCase {
+    private final Logger logger = LoggerFactory.getLogger(SectionControllerTests.class);
+    private ObjectMapper mapper = new ObjectMapper();
+
+    @MockBean
+    PSCourseRepository pscourseRepository;
+
+    @MockBean
+    UserRepository userRepository;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private UCSBCurriculumService ucsbCurriculumService;
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void api_sections_admin__user_logged_in__returns_200() throws Exception {
+        mockMvc.perform(get("/api/sections/getsections?psId=7"))
+                .andExpect(status().is(200));
+    }
+
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void test_section_search() throws Exception {
+
+        CoursePage cp = CoursePage.fromJSON(CoursePageFixtures.COURSE_PAGE_JSON_MATH3B);
+        List<CourseInfo> convertedSections = cp.convertedSectionsInfo();
+        List<CourseInfo> empty = new ArrayList<CourseInfo>();
+        assertNotEquals(empty, convertedSections);
+        ObjectMapper objectMapper = new ObjectMapper();
+        String expectedResult = objectMapper.writeValueAsString(convertedSections);
+
+        String urlTemplate = "/api/sections/getsections?psId=%s";
+        String url = String.format(urlTemplate, "7");
+        when(ucsbCurriculumService.getConvertedSectionsByQuarterAndEnroll(any(String.class), any(String.class)))
+	    .thenReturn(convertedSections);
+
+
+        PSCourse p7 = PSCourse.builder().psId(7).enrollCd("77777").quarter("20223").id(0L).build();
+        ArrayList<PSCourse> expectedPSCourse = new ArrayList<>();
+        expectedPSCourse.addAll(Arrays.asList(p7));
+        when(pscourseRepository.findAllByPsId(any(Long.class))).thenReturn(expectedPSCourse);
+
+
+        MvcResult response = mockMvc.perform(get(url).contentType("application/json")).andExpect(status().isOk())
+                .andReturn();
+        String responseString = response.getResponse().getContentAsString();
+
+        assertEquals(expectedResult, responseString);
+    }
+}

--- a/src/test/java/edu/ucsb/cs156/courses/documents/CoursePageFixtures.java
+++ b/src/test/java/edu/ucsb/cs156/courses/documents/CoursePageFixtures.java
@@ -2,6 +2,134 @@ package edu.ucsb.cs156.courses.documents;
 
 public class CoursePageFixtures {
 
+    public static final String CS777original = """
+          {
+                       "pageNumber": 1,
+                       "pageSize": 10,
+                       "total": 1,
+                       "classes": [
+            {
+              "quarter": "20222",
+              "courseId": "CMPSC   777E ",
+              "title": "SPEC TOP SYS ARCH",
+              "contactHours": 30,
+              "description": "These courses provide for the study of topics of current interest in computer   science systems.",
+              "college": "ENGR",
+              "objLevelCode": "G",
+              "subjectArea": "CMPSC   ",
+              "unitsFixed": 4,
+              "unitsVariableHigh": null,
+              "unitsVariableLow": null,
+              "delayedSectioning": null,
+              "inProgressCourse": null,
+              "gradingOption": "L",
+              "instructionType": "LEC",
+              "onLineCourse": false,
+              "deptCode": "CMPSC",
+              "generalEducation": [],
+              "classSections": [
+                {
+                  "enrollCode": "77777",
+                  "section": "0100",
+                  "session": null,
+                  "classClosed": "Y",
+                  "courseCancelled": null,
+                  "gradingOptionCode": null,
+                  "enrolledTotal": 23,
+                  "maxEnroll": 35,
+                  "secondaryStatus": null,
+                  "departmentApprovalRequired": false,
+                  "instructorApprovalRequired": false,
+                  "restrictionLevel": null,
+                  "restrictionMajor": "+CMPSC",
+                  "restrictionMajorPass": null,
+                  "restrictionMinor": null,
+                  "restrictionMinorPass": null,
+                  "concurrentCourses": [],
+                  "timeLocations": [
+                    {
+                      "room": "3526",
+                      "building": "PHELP",
+                      "roomCapacity": null,
+                      "days": "M W    ",
+                      "beginTime": "11:00",
+                      "endTime": "12:50"
+                    }
+                  ],
+                  "instructors": [
+                    {
+                      "instructor": "SHERWOOD T P",
+                      "functionCode": "Teaching and in charge"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+    """;
+    public static final String CS777 = """
+          [
+            {
+              "quarter": "20222",
+              "courseId": "CMPSC   777E ",
+              "title": "SPEC TOP SYS ARCH",
+              "contactHours": 30,
+              "description": "These courses provide for the study of topics of current interest in computer   science systems.",
+              "college": "ENGR",
+              "objLevelCode": "G",
+              "subjectArea": "CMPSC   ",
+              "unitsFixed": 4,
+              "unitsVariableHigh": null,
+              "unitsVariableLow": null,
+              "delayedSectioning": null,
+              "inProgressCourse": null,
+              "gradingOption": "L",
+              "instructionType": "LEC",
+              "onLineCourse": false,
+              "deptCode": "CMPSC",
+              "generalEducation": [],
+              "classSections": [
+                {
+                  "enrollCode": "77777",
+                  "section": "0100",
+                  "session": null,
+                  "classClosed": "Y",
+                  "courseCancelled": null,
+                  "gradingOptionCode": null,
+                  "enrolledTotal": 23,
+                  "maxEnroll": 35,
+                  "secondaryStatus": null,
+                  "departmentApprovalRequired": false,
+                  "instructorApprovalRequired": false,
+                  "restrictionLevel": null,
+                  "restrictionMajor": "+CMPSC",
+                  "restrictionMajorPass": null,
+                  "restrictionMinor": null,
+                  "restrictionMinorPass": null,
+                  "concurrentCourses": [],
+                  "timeLocations": [
+                    {
+                      "room": "3526",
+                      "building": "PHELP",
+                      "roomCapacity": null,
+                      "days": "M W    ",
+                      "beginTime": "11:00",
+                      "endTime": "12:50"
+                    }
+                  ],
+                  "instructors": [
+                    {
+                      "instructor": "SHERWOOD T P",
+                      "functionCode": "Teaching and in charge"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+    """;
+    
     public static final String COURSE_PAGE_JSON_MATH3B = """
                    {
                        "pageNumber": 1,

--- a/src/test/java/edu/ucsb/cs156/courses/documents/CoursePageTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/documents/CoursePageTests.java
@@ -16,10 +16,10 @@ public class CoursePageTests {
 
     @Test
     public void convertsCoursePageToObject()  {
-        CoursePage cp = CoursePage.fromJSON(CoursePageFixtures.COURSE_PAGE_JSON);
+        CoursePage cp = CoursePage.fromJSON(CoursePageFixtures.COURSE_PAGE_JSON_MATH3B);
         assertEquals(1, cp.getPageNumber());
         assertEquals(10, cp.getPageSize());
-        assertEquals(49, cp.getTotal());
+        assertEquals(1, cp.getTotal());
     }
 
 

--- a/src/test/java/edu/ucsb/cs156/courses/services/UCSBCurriculumServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/services/UCSBCurriculumServiceTests.java
@@ -27,6 +27,7 @@ import org.springframework.test.web.client.MockRestServiceServer;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
 
+import edu.ucsb.cs156.courses.documents.CourseInfo;
 import edu.ucsb.cs156.courses.documents.ConvertedSection;
 import edu.ucsb.cs156.courses.documents.CoursePageFixtures;
 import edu.ucsb.cs156.courses.documents.SectionFixtures;
@@ -225,6 +226,33 @@ public class UCSBCurriculumServiceTests {
         List<ConvertedSection> convertedSections = ucs.getConvertedSections(subjectArea, quarter, level);
         List<ConvertedSection> expected = objectMapper.readValue(CoursePageFixtures.CONVERTED_SECTIONS_JSON_MATH5B,
                 new TypeReference<List<ConvertedSection>>() {
+                });
+
+        assertEquals(expected, convertedSections);
+    }
+
+    @Test
+    public void test_getConvertedSectionsByQuarterAndEnroll() throws Exception {
+	String expectedResult = CoursePageFixtures.CS777original;
+        String quarter = "20222";
+        String enrollCd = "77777";
+
+	String expectedParams = String.format(
+                "?quarter=%s&enrollCode=%s&pageNumber=%d&pageSize=%d&includeClassSections=true", quarter,
+                enrollCd, 1, 100);
+        String expectedURL = "https://api.ucsb.edu/academics/curriculums/v3/classes/search" + expectedParams;
+        this.mockRestServiceServer.expect(requestTo(expectedURL))
+                .andExpect(header("Accept", MediaType.APPLICATION_JSON.toString()))
+                .andExpect(header("Content-Type", MediaType.APPLICATION_JSON.toString()))
+                .andExpect(header("ucsb-api-version", "3.0"))
+                .andExpect(header("ucsb-api-key", apiKey))
+                .andRespond(withSuccess(expectedResult, MediaType.APPLICATION_JSON));
+
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        List<CourseInfo> convertedSections = ucs.getConvertedSectionsByQuarterAndEnroll(quarter, enrollCd);
+        List<CourseInfo> expected = objectMapper.readValue(CoursePageFixtures.CS777,
+                new TypeReference<List<CourseInfo>>() {
                 });
 
         assertEquals(expected, convertedSections);


### PR DESCRIPTION
To close #26 
# Overview
Added endpoint that returns, for a personal schedule, a list of all of the enrollCd's of the sections in the database that are in that personal schedule.
Revised Courses entity & repository, Course, CourseInfo, CoursePage,UCSBCurriculumService for applying functions in SectionController.
Implemented tests for SectionController, CoursePage, and UCSBCurriculumService.
Passed all Cl/CD.